### PR TITLE
Appending nil unicodeString

### DIFF
--- a/PDFKitten/StringDetector.m
+++ b/PDFKitten/StringDetector.m
@@ -107,7 +107,9 @@
 	// Use Unicode string to compare with user input.
 	NSString *unicodeString = [[font stringWithPDFString:string] lowercaseString];
 	
-	[unicodeContent appendString:unicodeString];
+    if (unicodeString) {
+        [unicodeContent appendString:unicodeString];
+    }
 		
 	for (int i = 0; i < [unicodeString length]; i++)
 	{


### PR DESCRIPTION
I have no real knowledge of the PDF parsing process but this seems to be a trivial fix. With some PDFs the app crashed on this line due to nil unicodeString, so I just added a check.
