### PR TITLE
Remove the stringDetector delegate after scanning

### DIFF
--- a/PDFKitten/Scanner.m
+++ b/PDFKitten/Scanner.m
@@ -31,6 +31,9 @@
 	CGPDFContentStreamRelease(contentStream);
 	CGPDFOperatorTableRelease(operatorTable);
 	
+    self.stringDetector.delegate = nil;
+    self.stringDetector = nil;
+    
 	return self.selections;
 }
 
@@ -126,7 +129,6 @@
 	[renderingStateStack release];
 	[stringDetector release];
 	[content release];
-    [selections release];
 	[super dealloc];
 }
 


### PR DESCRIPTION
It's a tiny memory related fix, I saw this when trying to integrate this library with another PDF library. Hope it helps.
