### PR TITLE
Resolves infinite recursion issue in CMap.m

### DIFF
--- a/PDFKitten/CMap.m
+++ b/PDFKitten/CMap.m
@@ -171,6 +171,16 @@ NSValue *rangeValue(unsigned int from, unsigned int to)
 	NSString *token = nil;
 	[scanner scanUpToCharactersFromSet:self.tokenDelimiterSet intoString:&token];
 
+	if ( !token )
+	{
+		// There's no token delimiters left in the scanner, so we need to scan to the end.
+		
+		// Get the remainder of the scanner's string
+		token = [[scanner string] substringFromIndex:[scanner scanLocation]];
+		// Advance the scanner to the end of the string
+		[scanner scanString:token intoString:nil];
+	}
+	
 	static NSString *commentMarker = @"%%";
 	NSRange commentMarkerRange = [token rangeOfString:commentMarker];
 	if (commentMarkerRange.location != NSNotFound)


### PR DESCRIPTION
If the scanner's string does not end with a token delimiter, NSScanner will return a nil token; this ensures that token is always the remainder of the string.

Fixes #82.